### PR TITLE
Skip code from `pythonpy` itself in tracebacks.

### DIFF
--- a/pythonpy/__main__.py
+++ b/pythonpy/__main__.py
@@ -189,10 +189,17 @@ try:
         exec(args.post_cmd)
 except Exception:
     import traceback
-    header = 'File "{}"'.format(__file__)
+    pyheader = 'File "{}"'.format(__file__)
+    exprheader = 'File "<string>"'
+    foundexpr = False
     lines = traceback.format_exception(*sys.exc_info())
-    lines = (line for line in lines if not line.lstrip().startswith(header))
-    sys.stderr.write(''.join(lines))
+    for line in lines:
+        if line.lstrip().startswith(pyheader):
+            continue
+        sys.stderr.write(line)
+        if not foundexpr and line.lstrip().startswith(exprheader):
+            sys.stderr.write('    {}\n'.format(args.expression))
+            foundexpr = True
 
 def main():
     pass

--- a/pythonpy/__main__.py
+++ b/pythonpy/__main__.py
@@ -187,9 +187,12 @@ try:
 
     if args.post_cmd:
         exec(args.post_cmd)
-except Exception as ex:
+except Exception:
     import traceback
-    sys.stderr.write(traceback.format_exc())
+    header = 'File "{}"'.format(__file__)
+    lines = traceback.format_exception(*sys.exc_info())
+    lines = (line for line in lines if not line.lstrip().startswith(header))
+    sys.stderr.write(''.join(lines))
 
 def main():
     pass


### PR DESCRIPTION
See #54 for details.