### PR TITLE
Modify setup to install completions more portably.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,24 +2,40 @@
 from setuptools import setup
 import os
 import sys
+import tempfile
 
-if os.geteuid() == 0:
-    data_files = [('/etc/bash_completion.d', ['pythonpy/pycompletion.sh']),]
+for path in os.environ['PATH'].split(':'):
+    target = os.path.join(os.path.dirname(path), 'etc', 'bash_completion.d')
+    if os.path.isdir(target):
+        break
 else:
-    if sys.argv[1] == 'install':
-        print(
+    # Fall back to the default used by many Linux distros
+    target = '/etc/bash_completion.d'
+
+try:
+    with tempfile.TemporaryFile(dir=target) as t:
+        pass
+except OSError as e:
+    print(
 '''******************************************************************************
-Looks like you didn't run this command using sudo.
-Pythonpy needs root privileges to copy pycompletion.sh to /etc/bash_completion.d
-1) If you are in a virtualenv, you can configure tab completion without root using:
-    source /path/to/virtualenv/bash_completion.d/pycompletion.sh
-2) If you aren't using virtualenv, remember that pip requires sudo by default
-    on most systems. py is a simple python script that does not require any
-    root access or special privileges. If you don't like using root,
-    learn virtualenv and refer to 1).
+Pythonpy can't create a file in:
+    {}
+The error was:
+    {}
+It looks like you either didn't run this command using sudo, or don't have
+bash completions set up.
+1) If this is intentional (e.g., because you're in a virtualenv), you can
+   configure tab completion without root using:
+   source /path/to/virtualenv/bash_completion.d/pycompletion.sh
+2) Otherwise, remember that pip requires sudo by default
+   on most systems. py is a simple python script that does not require any
+   root access or special privileges. If you don't like using root,
+   learn virtualenv and refer to 1).
 Installation proceeding without root access...
 ******************************************************************************''')
-    data_files = [('bash_completion.d', ['pythonpy/pycompletion.sh']),]
+    target='bash_completion.d'
+
+data_files = [(target, ['pythonpy/pycompletion.sh']),]
 
 py_entry = 'py%s = pythonpy.__main__:main'
 pycompleter_entry = 'pycompleter%s = pythonpy.pycompleter:main'


### PR DESCRIPTION
The current `setup.py` only works on systems where bash completions are in `/etc`. While that's true for some Linux distros, it's not at all universal. Also, the test for `sudo` and the warning text are wrong for most OS X users. This updated version should be a lot more portable, and more informative when it fails.

I've tested on a Mac with Apple `bash` and Homebrew `bash-completion`, a Mac with MacPorts `bash` and `bash-completion`, a Fedora box with the standard `bash` and completions, and a Windows box with Cygwin `bash` and `bash-completion`. It's probably worth testing other platforms—especially MSYS or other native Windows `bash`, but also maybe FreeBSD and some other Linux distros.

Checkin comments below:

- Bash completions may be stored in `/usr/local/etc`, `/opt/local/etc`,
  or other places besides `/etc`. In particular:
  - OS X `bash` doesn't come with completions by default; installing them
    manually or with Homebrew puts them in `/usr/local`.
  - OS X users who replace Apple's `bash` (because it's 3.2, and uses
    `libedit` instead of `libreadline`) usually do so with Homebrew
    (`/usr/local`), a manual build (`/usr/local`), or MacPorts
    (`/opt/local`), although other options (Fink, Gentoo Prefix, etc.)
    exist.
  - Most *BSD systems have completions in ports rather than base (or
    the relevant equivalent), so again they go into `/usr/local`.
  - I have no idea how well this will work for Windows users using
    MSYS or other native `bash`, but my guess is that if this doesn't
    work, the only thing that will is custom Windows code. At any rate,
    the worst case is that we fall back to installing the completion
    locally.
  - The new version searches every path in `$PATH`, looking for a
    `../etc/bash_completion.d`, and uses the first one it finds.
- `pip` doesn't always require `sudo` outside a virtualenv.
 - On OS X, the Python.org installer and Homebrew both, by default,
   give you a site-packages that's group- or world-writable. Fortunately,
   people who use such a Python are usually using a group- or world-
   writable bash-completions as well.
 - `pip --user` of course doesn't need it either.
 - Windows users have a world-writable site-packages (and don't have
  `sudo`).
 - The simplest thing to do is check whether the discovered directory
   is writable, instead of checking whether we're running as root.
- These changes required some minor rewrites to the warning message.
 - This might need updates for Windows `bash` users... or maybe anyone
   using native `bash` on Windows should be expected to know what they're
   doing...