### PR TITLE
Fix test suite

### DIFF
--- a/test/test_pythonpy.py
+++ b/test/test_pythonpy.py
@@ -30,7 +30,7 @@ class TestPythonPy(unittest.TestCase):
                            "calendar.weekday(1955, 11, 5)",
                            "csv.list_dialects()",
                            "datetime.timedelta(hours=-5)",
-                           "hashlib.sha224(\"Nobody inspects the spammish repetition\").hexdigest()",
+                           "hashlib.sha224(\"Nobody inspects the spammish repetition\".encode(\"utf-8\")).hexdigest()",
                            "glob.glob('*')",
                            "itertools.product(['a','b'], [1,2])",
                            "json.dumps([1,2,3,{'4': 5, '6': 7}], separators=(',',':'))",


### PR DESCRIPTION
Hi Russel,

There were two problems with the test suite. The first one is that it lacked the `__init__.py` file in the `test/` directory, so the tests couldn't be auto discovered. The second one was that one of them was failing with a `TypeError: Unicode-objects must be encoded before hashing` that can be easily fixed.

Regards,
Tiago.