### PR TITLE
Add classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,10 @@ setup(
     entry_points = {
         'console_scripts': entry_points_scripts
     },
+    classifiers = [
+        # https://pypi.org/pypi?%3Aaction=list_classifiers
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+  ],
 )


### PR DESCRIPTION
Classifiers are metadata about packages on PyPI. The information about Python version support shows on the PyPI project page and is used by tools such as [caniusepython3](https://caniusepython3.com/).